### PR TITLE
feat: 공통 클래스(응답, 예외 등) 구현

### DIFF
--- a/src/main/java/com/hayan/hello_traveler/HelloTravelerApplication.java
+++ b/src/main/java/com/hayan/hello_traveler/HelloTravelerApplication.java
@@ -2,12 +2,14 @@ package com.hayan.hello_traveler;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class HelloTravelerApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(HelloTravelerApplication.class, args);
-	}
+  public static void main(String[] args) {
+    SpringApplication.run(HelloTravelerApplication.class, args);
+  }
 
 }

--- a/src/main/java/com/hayan/hello_traveler/common/entity/BaseEntity.java
+++ b/src/main/java/com/hayan/hello_traveler/common/entity/BaseEntity.java
@@ -1,0 +1,30 @@
+package com.hayan.hello_traveler.common.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @CreatedDate
+  @Column(updatable = false)
+  private LocalDateTime createdAt;
+
+  @LastModifiedDate
+  private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/hayan/hello_traveler/common/entity/BaseIdEntity.java
+++ b/src/main/java/com/hayan/hello_traveler/common/entity/BaseIdEntity.java
@@ -1,0 +1,16 @@
+package com.hayan.hello_traveler.common.entity;
+
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+
+@Getter
+@MappedSuperclass
+public abstract class BaseIdEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+}

--- a/src/main/java/com/hayan/hello_traveler/common/exception/CustomException.java
+++ b/src/main/java/com/hayan/hello_traveler/common/exception/CustomException.java
@@ -1,0 +1,21 @@
+package com.hayan.hello_traveler.common.exception;
+
+import com.hayan.hello_traveler.common.response.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException {
+
+  private final ErrorCode errorCode;
+
+  public CustomException(ErrorCode errorCode) {
+    super(errorCode.getMessage());
+    this.errorCode = errorCode;
+  }
+
+  public CustomException(ErrorCode errorCode, String message) {
+    super(message);
+    this.errorCode = errorCode;
+  }
+
+}

--- a/src/main/java/com/hayan/hello_traveler/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/hayan/hello_traveler/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,55 @@
+package com.hayan.hello_traveler.common.exception;
+
+import com.hayan.hello_traveler.common.response.ApplicationResponse;
+import com.hayan.hello_traveler.common.response.ErrorCode;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.stream.Collectors;
+import org.hibernate.exception.ConstraintViolationException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.support.DefaultMessageSourceResolvable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+  private static final Logger logger = LoggerFactory.getLogger(GlobalExceptionHandler.class);
+
+  @ExceptionHandler(CustomException.class)
+  public ResponseEntity<ApplicationResponse<Void>> handleCustomException(CustomException e) {
+    return buildErrorResponse(e.getErrorCode(), e.getMessage());
+  }
+
+  @ExceptionHandler(RuntimeException.class)
+  public ResponseEntity<ApplicationResponse<Void>> handleUnexpectedException(RuntimeException e) {
+    logger.error("Unexpected Exception: {}", e.getMessage(), e);
+    return buildErrorResponse(ErrorCode.INTERNAL_SERVER_ERROR, e.getMessage());
+  }
+
+  @ExceptionHandler(MethodArgumentNotValidException.class)
+  public ResponseEntity<ApplicationResponse<Void>> handleMethodArgumentNotValidException(
+      HttpServletRequest request, MethodArgumentNotValidException e) {
+    String errorMessage = e.getBindingResult().getAllErrors().stream()
+        .map(DefaultMessageSourceResolvable::getDefaultMessage)
+        .collect(Collectors.joining(", "));
+    logger.error("Validation Error: {}, Request URI: {}", errorMessage, request.getRequestURI());
+    return buildErrorResponse(ErrorCode.REQUEST_VALIDATION_FAIL, errorMessage);
+  }
+
+  @ExceptionHandler(ConstraintViolationException.class)
+  public ResponseEntity<ApplicationResponse<Void>> handleConstraintViolationException(
+      HttpServletRequest request, ConstraintViolationException e) {
+    logger.error("ConstraintViolationException: {}, Request URI: {}", e.getMessage(),
+        request.getRequestURI());
+    return buildErrorResponse(ErrorCode.REQUEST_VALIDATION_FAIL, e.getMessage());
+  }
+
+  private ResponseEntity<ApplicationResponse<Void>> buildErrorResponse(ErrorCode errorCode,
+      String message) {
+    ApplicationResponse<Void> response = ApplicationResponse.error(errorCode.getCode(), message);
+    return ResponseEntity.status(errorCode.getHttpStatus()).body(response);
+  }
+}

--- a/src/main/java/com/hayan/hello_traveler/common/response/ApplicationResponse.java
+++ b/src/main/java/com/hayan/hello_traveler/common/response/ApplicationResponse.java
@@ -1,0 +1,32 @@
+package com.hayan.hello_traveler.common.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class ApplicationResponse<T> {
+
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  private final T data;
+  private final String responseCode;
+  private final String responseMessage;
+
+  public static <T> ApplicationResponse<T> ok(T data, SuccessCode code) {
+    return new ApplicationResponse<>(data, code.getCode(), code.getMessage());
+  }
+
+  public static ApplicationResponse<Void> noData(SuccessCode code) {
+    return new ApplicationResponse<>(null, code.getCode(), code.getMessage());
+  }
+
+  public static ApplicationResponse<Void> error(ErrorCode code) {
+    return new ApplicationResponse<>(null, code.getCode(), code.getMessage());
+  }
+
+  public static ApplicationResponse<Void> error(String code, String message) {
+    return new ApplicationResponse<>(null, code, message);
+  }
+}

--- a/src/main/java/com/hayan/hello_traveler/common/response/ErrorCode.java
+++ b/src/main/java/com/hayan/hello_traveler/common/response/ErrorCode.java
@@ -1,0 +1,30 @@
+package com.hayan.hello_traveler.common.response;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+  // 400 Bad Request
+  REQUEST_VALIDATION_FAIL(BAD_REQUEST, "400", "잘못된 요청 값입니다."),
+
+  // 401 Unauthorized
+  UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "401", "인증에 실패했습니다."),
+
+  // 403 Forbidden
+
+  // 404 Not Found
+
+  // 409 Conflict
+
+  // 500
+  INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "500", "서버 내부 오류입니다.");
+
+  private final HttpStatus httpStatus;
+  private final String code;
+  private final String message;
+}

--- a/src/main/java/com/hayan/hello_traveler/common/response/ResponseCode.java
+++ b/src/main/java/com/hayan/hello_traveler/common/response/ResponseCode.java
@@ -1,0 +1,12 @@
+package com.hayan.hello_traveler.common.response;
+
+import org.springframework.http.HttpStatus;
+
+public interface ResponseCode {
+
+  HttpStatus getHttpStatus();
+
+  String getCode();
+
+  String getMessage();
+}

--- a/src/main/java/com/hayan/hello_traveler/common/response/SuccessCode.java
+++ b/src/main/java/com/hayan/hello_traveler/common/response/SuccessCode.java
@@ -1,0 +1,15 @@
+package com.hayan.hello_traveler.common.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum SuccessCode implements ResponseCode {
+  SUCCESS(HttpStatus.OK, "00", "success");
+
+  private final HttpStatus httpStatus;
+  private final String code;
+  private final String message;
+}


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- api 응답으로 사용하기 위한 ApplicationResponse 구현
  - 성공, 실패 응답 구조를 통일하는 것에 신경을 썼습니다. 그리고 Success Code에 값이 하나인데도 클래스로 둔 이유는 추후 성공 코드를 생성/ 조회/ 삭제 등 여러 상황에 맞추어 변경할 수 있는 가능성 때문입니다.
- 전역 예외 처리 클래스 구현 
- BaseEntity, BaseIdEntity 구현
  - createdAt, updatedAt은 필요 없지만 id는 필요한 클래스가 많아서 BaseEntity와 별도로 BaseIdEntity를 구현했습니다. id를 분리함으로써 중복 코드를 제거하고 @AllArgsConstructer를 사용할 수 있기 때문에 domain 코드가 깔끔해질 것으로 생각했습니다.

**TO-BE**

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [ ] API 테스트 
